### PR TITLE
Refactor the decode loop to prevent file handle already closed error.

### DIFF
--- a/src/Streaming/Cassava.hs
+++ b/src/Streaming/Cassava.hs
@@ -130,7 +130,7 @@ runParser = loop
       nxt <- lift (B.nextChunk str)
       let g = loop . f
       case nxt of
-        Left r -> pure $ Right r
+        Left r              -> pure $ Right r
         Right (chunk, rest) -> g chunk rest
 
     loop p str = case p of
@@ -190,14 +190,11 @@ decodeByNameWithErrors = loopH . CI.decodeByNameWith
                      PartialH get -> feedH get str
                      DoneH _  p   -> runParser p str
 
-    -- feedH f str = (uncurry (loopH . f) . fromMaybe (mempty, str))
-    --                        -- nxt == Nothing, str is just Return
-    --               =<< lift (B.unconsChunk str)
     feedH f str = do
       nxt <- lift (B.nextChunk str)
       let g = loopH . f
       case nxt of
-        Left r -> pure $ Right r
+        Left r              -> pure $ Right r
         Right (chunk, rest) -> g chunk rest
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I refactored the decode loop in `Streaming.Cassava.hs` to help prevent an error due to the file already being closed when using `readFile` from the streaming-bytestring package.

The root cause is likely incorrect use of MonadResource in the streaming-bytestring package. However this does prevent 1 extra call at the end of the decode loop for what it's worth.